### PR TITLE
Organization GitHub rename

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "silinternational/apiaxle-sdk-php",
+  "name": "sil-org/apiaxle-sdk-php",
   "description": "PHP client for ApiAxle APIs",
   "type": "library",
   "license": "MIT",


### PR DESCRIPTION
### Change (non-breaking)
- changed silinternational to sil-org in github reference